### PR TITLE
storage edits

### DIFF
--- a/templates/united_states/united_states_template.xml
+++ b/templates/united_states/united_states_template.xml
@@ -85,7 +85,6 @@
         <in_commods>
           <val>nat_u</val>
         </in_commods>
-        <in_recipe>nat_u</in_recipe>
         <out_commods>
           <val>u3o8</val>
         </out_commods>
@@ -103,7 +102,6 @@
         <in_commods>
           <val>u3o8</val>
         </in_commods>
-        <in_recipe>u3o8</in_recipe>
         <out_commods>
           <val>uf6</val>
         </out_commods>
@@ -137,7 +135,6 @@
         <in_commods>
           <val>enr_u</val>
         </in_commods>
-        <in_recipe>enr_u</in_recipe>
         <out_commods>
           <val>fresh_uox</val>
         </out_commods>
@@ -155,7 +152,6 @@
         <in_commods>
           <val>spent_uox</val>
         </in_commods>
-        <in_recipe>spent_uox</in_recipe>
         <out_commods>
           <val>cool_spent_uox</val>
         </out_commods>
@@ -173,7 +169,6 @@
         <in_commods>
           <val>cool_spent_uox</val>
         </in_commods>
-        <in_recipe>cool_spent_uox</in_recipe>
         <out_commods>
           <val>casked_spent_uox</val>
         </out_commods>


### PR DESCRIPTION
When merged, should solve #48 

I noticed that there is no `out_recipe` specified, my bad. However, I deleted some `in_recipe` in the Storage, since they might prevent some material that underwent decay to be accepted ( Actually we should see how 'rigorous' the `buypolicy` considers the recipe). 

Please let me know what you think about these changes.